### PR TITLE
catalog: rename PNGettext to NPGettext, to match GNU gettext

### DIFF
--- a/catalog.go
+++ b/catalog.go
@@ -70,12 +70,12 @@ func (c Catalog) PGettext(msgctxt, msgid string) string {
 	return msgid
 }
 
-// PNGettext returns a translation of the provided message using the
+// NPGettext returns a translation of the provided message using the
 // provided context and plural form.
 //
 // This method combines the functionality of the NGettext and PGettext
 // variants.
-func (c Catalog) PNGettext(msgctxt, msgid, msgidPlural string, n uint32) string {
+func (c Catalog) NPGettext(msgctxt, msgid, msgidPlural string, n uint32) string {
 	if msgstr, ok := c.findMsg(msgctxt+"\x04"+msgid, true, n); ok {
 		return msgstr
 	}

--- a/gettext_test.go
+++ b/gettext_test.go
@@ -97,10 +97,10 @@ func TestMessageContext(t *testing.T) {
 	assert_equal(t, es.PGettext("weapon", "bow"), "arco")
 
 	// A context can be used for ngettext style lookups too.
-	assert_equal(t, es.PNGettext("knot", "%d bow", "%d bows", 1), "%d lazo")
-	assert_equal(t, es.PNGettext("knot", "%d bow", "%d bows", 2), "%d lazos")
-	assert_equal(t, es.PNGettext("weapon", "%d bow", "%d bows", 1), "%d arco")
-	assert_equal(t, es.PNGettext("weapon", "%d bow", "%d bows", 2), "%d arcos")
+	assert_equal(t, es.NPGettext("knot", "%d bow", "%d bows", 1), "%d lazo")
+	assert_equal(t, es.NPGettext("knot", "%d bow", "%d bows", 2), "%d lazos")
+	assert_equal(t, es.NPGettext("weapon", "%d bow", "%d bows", 1), "%d arco")
+	assert_equal(t, es.NPGettext("weapon", "%d bow", "%d bows", 2), "%d arcos")
 
 	// There is no contextless translation
 	assert_equal(t, es.Gettext("bow"), "bow")
@@ -109,7 +109,7 @@ func TestMessageContext(t *testing.T) {
 	// With no catalog, the message ID is returned and context ignored
 	empty := trans.Locale()
 	assert_equal(t, empty.PGettext("knot", "bow"), "bow")
-	assert_equal(t, empty.PNGettext("knot", "%d bow", "%d bows", 1), "%d bow")
+	assert_equal(t, empty.NPGettext("knot", "%d bow", "%d bows", 1), "%d bow")
 }
 
 func TestFallbackCatalog(t *testing.T) {


### PR DESCRIPTION
I made a typo when adding message context support.  The name GNU Gettext uses for the context aware plural translation function is `npgettext` rather than `pngettext`:

https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=blob;f=gnulib-local/lib/gettext.h#l130

So this just adjusts the Go method name to match.