### PR TITLE
gettext: add langpack support

### DIFF
--- a/gettext.go
+++ b/gettext.go
@@ -3,9 +3,8 @@
 package gettext
 
 import (
-	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 )
 
@@ -32,12 +31,12 @@ type TextDomain struct {
 const DefaultLocaleDir = "/usr/share/locale"
 
 // PathResolver resolves a path to a mo file
-type PathResolver func(root string, locale string, domain string) string
+type PathResolver func(root, locale, domain string) string
 
 // DefaultResolver resolves paths in the standard format of:
 // <root>/<locale>/LC_MESSAGES/<domain>.mo
-func DefaultResolver(root string, locale string, domain string) string {
-	return path.Join(root, locale, "LC_MESSAGES", fmt.Sprintf("%s.mo", domain))
+func DefaultResolver(root, locale, domain string) string {
+	return filepath.Join(root, locale, "LC_MESSAGES", domain+".mo")
 }
 
 // Preload a list of locales (if they're available). This is useful if you want


### PR DESCRIPTION
This is a second approach to adding langpack support after PR #9.

This time around, setting `TextDomain.UseLangpacks` to `true` will cause catalogs to be loaded from both the configured locale dir and also the `/usr/share/locale-langpack` directory.

This required altering the mocatalog cache to key off of file names rather than locale identifiers so that a failure to load a regular catalog wouldn't block loading of a langpack catalog.