### PR TITLE
README: update to match current state of go-gettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,37 @@
 # gettext in golang
 
-[![Build Status](https://travis-ci.org/ojii/gettext.go.svg?branch=master)](https://travis-ci.org/ojii/gettext.go)
+[![Build Status](https://github.com/snapcore/go-gettext/workflows/test/badge.svg)](https://github.com/snapcore/go-gettext/actions)
+
+go-gettext is a pure Go implementation of the GNU Gettext
+internationalisation API. It loads the binary catalogs generated
+by `msgfmt` by memory mapping them, so there is very little overhead
+at startup. Translations are looked up using the data structures in
+the catalog directly (either a binary search or hash table lookup).
+
+In addition to the basic `Gettext` API it supports the `NGettext` and
+`PGettext` variants, supporting plural translations and translations
+requiring a context string respectively.
+
+
+## Example
+
+```go
+import "github.com/snapcore/go-gettext"
+
+domain := &gettext.TextDomain{
+	Name:      "messages",
+	LocaleDir: "path/to/translations",
+}
+// or use domain.Locale(lang...) to open a different locale's catalog
+locale := domain.UserLocale()
+
+fmt.Println(locale.Gettext("hello from gettext"))
+
+for i := 0; i <= 10; i++ {
+	fmt.Printf(locale.NGettext("%d thing\n", "%d things\n", uint32(i)), i)
+}
+```
+
 
 ## TODO
 
@@ -9,25 +40,5 @@
 - [ ] non-utf8 mo files (possible wontfix)
 - [x] gettext
 - [x] ngettext
+- [x] pgettext/npgettext
 - [x] managing mo files / sane API
-
-
-## Example
-
-
-```go
-
-import gettext
-
-translations := gettext.NewTranslations("path/to/translations/", "messages", gettext.DefaultResolver)
-
-locale := translations.Locale("en")
-
-fmt.Println(locale.Gettext("hello from gettext"))
-
-one := 1
-two := 2
-
-fmt.Println(fmt.Sprintf(locale.NGettext("%d thing", "%d things", uint32(one)), one))
-fmt.Println(fmt.Sprintf(locale.NGettext("%d thing", "%d things", uint32(two)), two))
-```


### PR DESCRIPTION
This is a simple one: update the README to more closely describe the state of the project.  This shows up at the start of pkg.go.dev documentation, so having some descriptive text at the start is better than a todo list.