### PR TITLE
filemapping: add support for io/fs (including e.g. go:embed filesystems)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ requiring a context string respectively.
 ```go
 import "github.com/snapcore/go-gettext"
 
+//go:embed translations
+var assets embed.FS
+
 domain := &gettext.TextDomain{
 	Name:      "messages",
-	LocaleDir: "path/to/translations",
+	LocaleDir: "./translations",
+	LocaleFS:  assets,  // leave away to use the filesystem directly
 }
 // or use domain.Locale(lang...) to open a different locale's catalog
 locale := domain.UserLocale()

--- a/filemapping.go
+++ b/filemapping.go
@@ -2,8 +2,8 @@ package gettext
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
-	"os"
 	"runtime"
 )
 
@@ -21,7 +21,7 @@ func (m *fileMapping) Close() error {
 	return m.closeMapping()
 }
 
-func openMapping(f *os.File) (*fileMapping, error) {
+func openMapping(f fs.File) (*fileMapping, error) {
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, err

--- a/filemapping_unix.go
+++ b/filemapping_unix.go
@@ -1,15 +1,22 @@
+//go:build !windows
 // +build !windows
 
 package gettext
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"syscall"
 )
 
-func (m *fileMapping) tryMap(f *os.File, size int64) error {
+func (m *fileMapping) tryMap(f fs.File, size int64) error {
 	var err error
-	m.data, err = syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_PRIVATE)
+	var of, ok = f.(*os.File)
+	if !ok {
+		return errors.New("virtual filesystem doesn't support mmap")
+	}
+	m.data, err = syscall.Mmap(int(of.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_PRIVATE)
 	if err != nil {
 		return err
 	}

--- a/filemapping_unix.go
+++ b/filemapping_unix.go
@@ -12,7 +12,7 @@ import (
 
 func (m *fileMapping) tryMap(f fs.File, size int64) error {
 	var err error
-	var of, ok = f.(*os.File)
+	of, ok := f.(*os.File)
 	if !ok {
 		return errors.New("virtual filesystem doesn't support mmap")
 	}

--- a/filemapping_windows.go
+++ b/filemapping_windows.go
@@ -1,16 +1,19 @@
 package gettext
 
 import (
-	"os"
 	"syscall"
 	"unsafe"
 )
 
 // Adapted from https://github.com/golang/exp/blob/master/mmap/mmap_windows.go
 
-func (m *fileMapping) tryMap(f *os.File, size int64) error {
+func (m *fileMapping) tryMap(f fs.File, size int64) error {
+	var of, ok = f.(*os.File)
+	if !ok {
+		return errors.New("virtual filesystem doesn't support mmap")
+	}
 	low, high := uint32(size), uint32(size>>32)
-	fmap, err := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READONLY, high, low, nil)
+	fmap, err := syscall.CreateFileMapping(syscall.Handle(of.Fd()), nil, syscall.PAGE_READONLY, high, low, nil)
 	if err != nil {
 		return err
 	}

--- a/filemapping_windows.go
+++ b/filemapping_windows.go
@@ -1,6 +1,8 @@
 package gettext
 
 import (
+	"io/fs"
+	"os"
 	"syscall"
 	"unsafe"
 )

--- a/filemapping_windows.go
+++ b/filemapping_windows.go
@@ -1,6 +1,7 @@
 package gettext
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"syscall"

--- a/filemapping_windows.go
+++ b/filemapping_windows.go
@@ -8,7 +8,7 @@ import (
 // Adapted from https://github.com/golang/exp/blob/master/mmap/mmap_windows.go
 
 func (m *fileMapping) tryMap(f fs.File, size int64) error {
-	var of, ok = f.(*os.File)
+	of, ok := f.(*os.File)
 	if !ok {
 		return errors.New("virtual filesystem doesn't support mmap")
 	}

--- a/gettext_test.go
+++ b/gettext_test.go
@@ -1,6 +1,7 @@
 package gettext
 
 import (
+	"embed"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -272,11 +273,11 @@ func TestNotMoFile(t *testing.T) {
 
 }
 
-func TestFS(t *testing.T) {
-	// Can't use go:embed here for compatibility reasons as it's only supported since Go 1.16
-	testdata := os.DirFS("./testdata")
+//go:embed testdata
+var assets embed.FS
 
-	translations := &TextDomain{Name: "messages", LocaleDir: ".", LocaleFS: testdata, PathResolver: my_resolver}
+func TestFS(t *testing.T) {
+	translations := &TextDomain{Name: "messages", LocaleDir: "testdata", LocaleFS: assets, PathResolver: my_resolver}
 	en := translations.Locale("en")
 	assert_equal(t, en.Gettext("greeting"), "Hello")
 }

--- a/gettext_test.go
+++ b/gettext_test.go
@@ -271,3 +271,12 @@ func TestNotMoFile(t *testing.T) {
 	)
 
 }
+
+func TestFS(t *testing.T) {
+	// Can't use go:embed here for compatibility reasons as it's only supported since Go 1.16
+	testdata := os.DirFS("./testdata")
+
+	translations := &TextDomain{Name: "messages", LocaleDir: ".", LocaleFS: testdata, PathResolver: my_resolver}
+	en := translations.Locale("en")
+	assert_equal(t, en.Gettext("greeting"), "Hello")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/snapcore/go-gettext
 
-go 1.13
+go 1.18

--- a/mofile.go
+++ b/mofile.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io/fs"
 	"os"
 	"sort"
 	"strings"
@@ -223,7 +224,7 @@ func ParseMO(file *os.File) (Catalog, error) {
 	return Catalog{[]*mocatalog{mo}}, nil
 }
 
-func parseMO(file *os.File) (*mocatalog, error) {
+func parseMO(file fs.File) (*mocatalog, error) {
 	m, err := openMapping(file)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This allows to e.g. use `//go:embed locales` to build the locales into the binary.